### PR TITLE
README: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ Viddy well, gopher. Viddy well.
 
 ### Mac
 
+...via [Homebrew](https://brew.sh):
+
 ```shell
 brew install sachaos/tap/viddy
+```
+
+...via [MacPorts](https://www.macports.org):
+
+```shell
+sudo port install viddy
 ```
 
 ### Linux


### PR DESCRIPTION
Thanks for `viddy` - it's been added to [MacPorts](https://www.macports.org), so now that's another installation option for Mac users.