### PR TITLE
Support pressing Q to quit help view

### DIFF
--- a/viddy.go
+++ b/viddy.go
@@ -533,7 +533,7 @@ func (v *Viddy) Run() error {
 			any = true
 		}
 
-		if event.Key() == tcell.KeyEsc {
+		if event.Key() == tcell.KeyEsc || event.Rune() == 'q' {
 			v.showHelpView = false
 			v.arrange()
 		}
@@ -659,7 +659,7 @@ func (v *Viddy) goToOldestOnTimeMachine() {
 	}
 }
 
-var helpTemplate = `Press ESC to go back
+var helpTemplate = `Press ESC or Q to go back
 
  [::b]Key Bindings[-:-:-]
 


### PR DESCRIPTION
Add support for pressing `Q` as an alternative for `Esc` when on help view in order to return to default screen

`Q` is much more intuitive than `Esc` when trying to quit something, also much closer to default hand position.