### PR TITLE
Escape Snapshot result before rendering

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -124,7 +124,7 @@ func isWhiteString(str string) bool {
 }
 
 func (s *Snapshot) render(w io.Writer, isShowDiff bool, query string) error {
-	src := string(s.result)
+	src := tview.Escape(string(s.result))
 
 	if isWhiteString(src) {
 		src = string(s.errorResult)


### PR DESCRIPTION
fix #31 

tview recommends using the escape function before rendering.
By using this, you can prevent the coloring, region and more format from being used unintentionally.

https://pkg.go.dev/github.com/rivo/tview#Escape