### PR TITLE
Switched to go 1.18 in go.mod

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.41.1
+          version: v1.46.2
           args: -c .golang-ci.yml
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sachaos/viddy
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect


### PR DESCRIPTION
Hi viddy team,

First of all thx for the awesome cross-platform `watch` alternative 

Can I ask you to upgrade the go version (1.18) to pass `go mod tidy`.

Looks like viddy builds and works correctly on go 1.18.

Thx in advance!