### PR TITLE
Features/watch interval

### DIFF
--- a/config.go
+++ b/config.go
@@ -359,3 +359,14 @@ func keyOf(key string) (tcell.Key, error) {
 
 	return 0, keyNotFoundError{}
 }
+
+func isFlagSet(str string, flagSet *pflag.FlagSet) bool {
+	res := false
+	flagSet.Visit(func (f *pflag.Flag) {
+		if f.Name == str {
+			res = true
+		}
+	})
+
+	return res
+}

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -97,6 +98,13 @@ func newConfig(v *viper.Viper, args []string) (*config, error) {
 	var conf config
 
 	intervalStr, _ := flagSet.GetString("interval")
+	isIntervalFlagSet := isFlagSet("interval", flagSet)
+	if !isIntervalFlagSet {
+		if value, ok := os.LookupEnv("WATCH_INTERVAL"); ok {
+			fmt.Println("ok")
+			intervalStr = fmt.Sprintf("%ss", value)
+		}
+	}
 
 	interval, err := parseInterval(intervalStr)
 	if err != nil {


### PR DESCRIPTION
Feature request for [issue45](https://github.com/sachaos/viddy/issues/45)

Add usage of WATCH_INTERVAL env var for viddy.
- If user provides `-n` flag, `WATCH_INTERVAL` is not checked
- If interval flag is not provided, value from `WATCH_INTERVAL` is used
- If `WATCH_INTERVAL` is not set (and `-n` is not provided), default interval value (which is `2s`) is used