### PR TITLE
Feature/fill circle

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,14 +37,15 @@ type runtimeConfig struct {
 }
 
 type general struct {
-	shell        string
-	shellOptions string
-	debug        bool
-	bell         bool
-	differences  bool
-	noTitle      bool
-	pty          bool
-	unfold       bool
+	shell         string
+	shellOptions  string
+	debug         bool
+	bell          bool
+	differences   bool
+	noTitle       bool
+	pty           bool
+	unfold        bool
+	accessibility bool
 }
 
 type theme struct {
@@ -127,6 +128,8 @@ func newConfig(v *viper.Viper, args []string) (*config, error) {
 
 	v.SetDefault("general.shell", "sh")
 
+	v.SetDefault("general.accessibility", false)
+
 	if err := v.BindPFlag("general.shell_options", flagSet.Lookup("shell-options")); err != nil {
 		return nil, err
 	}
@@ -159,6 +162,7 @@ func newConfig(v *viper.Viper, args []string) (*config, error) {
 	conf.general.noTitle, _ = flagSet.GetBool("no-title")
 	conf.general.unfold = v.GetBool("general.unfold")
 	conf.general.pty = v.GetBool("general.pty")
+	conf.general.accessibility = v.GetBool("general.accessibility")
 
 	v.SetDefault("color.border", "gray")
 	v.SetDefault("color.title", "gray")

--- a/viddy.go
+++ b/viddy.go
@@ -348,18 +348,22 @@ func (v *Viddy) renderSnapshot(id int64) error {
 }
 
 func (v *Viddy) UpdateStatusView() {
-	v.statusView.SetText(fmt.Sprintf("Suspend %s  Diff %s  Bell %s",
-		convertToOnOrOff(v.isSuspend),
-		convertToOnOrOff(v.isShowDiff),
-		convertToOnOrOff(v.isRingBell)))
+	a := v.isAccessibility
+	v.statusView.SetText(fmt.Sprintf("%s  %s  %s",
+		convertToOnOrOff(v.isSuspend, "Suspend", a),
+		convertToOnOrOff(v.isShowDiff, "Diff", a),
+		convertToOnOrOff(v.isRingBell, "Bell", a)))
 }
 
-func convertToOnOrOff(on bool) string {
+func convertToOnOrOff(on bool, statusStr string, accessibility bool) string {
 	if on {
-		return "[green]◯[reset]"
+		if accessibility {
+			return fmt.Sprintf("[black:white]%s ⬤[-:-]", statusStr)
+		}
+		return fmt.Sprintf("%s [green]◯[reset]", statusStr)
 	}
 
-	return "[red]◯[reset]"
+	return fmt.Sprintf("%s [red]◯[-]", statusStr)
 }
 
 func (v *Viddy) arrange() {
@@ -687,7 +691,7 @@ var helpTemplate = `Press ESC or Q to go back
 
  [::b]Key Bindings[-:-:-]
 
-   [::u]General[-:-:-]     
+   [::u]General[-:-:-]
 
    Toggle time machine mode  : [yellow]SPACE[-:-:-]
    Toggle suspend execution  : [yellow]s[-:-:-]

--- a/viddy.go
+++ b/viddy.go
@@ -75,9 +75,10 @@ type Viddy struct {
 
 	query string
 
-	isDebug      bool
-	showLogView  bool
-	showHelpView bool
+	isDebug         bool
+	showLogView     bool
+	showHelpView    bool
+	isAccessibility bool
 }
 
 type ViddyIntervalMode string
@@ -135,6 +136,7 @@ func NewViddy(conf *config) *Viddy {
 		isDebug:    conf.general.debug,
 		unfold:     conf.general.unfold,
 		pty:        conf.general.pty,
+		isAccessibility: conf.general.accessibility,
 
 		currentID:        -1,
 		latestFinishedID: -1,


### PR DESCRIPTION
Feature request done for [issue 48](https://github.com/sachaos/viddy/issues/48)

Changelog:
* Ability to set `general.accessibility` in `config.toml` file for viddy
* Change to fill circle upon setting on the option of `Suspend, Diff, Bell` when `accessibility` is set to `true`
* And change the foreground color to black and background color to white (for better contrast)
* If `accessibility` is set to false, viddy behaves as it did before