### PR TITLE
fix: set eastasian width to fix broken layout

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/fatih/color"
+	"github.com/mattn/go-runewidth"
 	"github.com/rivo/tview"
 	"github.com/spf13/viper"
 	"github.com/tcnksm/go-latest"
@@ -32,6 +33,8 @@ func printVersion() {
 }
 
 func main() {
+	runewidth.DefaultCondition.EastAsianWidth = false
+
 	v := viper.New()
 	v.SetConfigType("toml")
 	v.SetConfigName("viddy")


### PR DESCRIPTION
Box layout in the top of screen is broken when using CJK locales.

The following is a screenshot, using MacOS 12.4, iTerm2 3.4.16, and `LANG=ja_JP.UTF-8`

![スクリーンショット 2022-08-12 23 54 17](https://user-images.githubusercontent.com/299936/184392545-ec32d7fb-c363-41a9-b3d7-b8ee37a38ced.png)

The first letter of titles aren't displayed, and box layout is broken.

The reason is that those box-drawing characters are ambiguous width ones, which will be displayed with a narrow width with non-CJK locales, but with wide width with CJK, which would break layout.
One way to fix it is to override `DefaultCondition.EastAsianWidth` variable in `go-runewidth` with `false`, so that any ambiguous width charactes would always be displayed with narrow width.
