### PR TITLE
Viddy as an importable package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/adrg/xdg"
 	"github.com/fatih/color"
-	"github.com/rivo/tview"
-	"github.com/spf13/viper"
+	"github.com/sachaos/viddy/viddy"
 	"github.com/tcnksm/go-latest"
 )
 
@@ -32,31 +30,16 @@ func printVersion() {
 }
 
 func main() {
-	v := viper.New()
-	v.SetConfigType("toml")
-	v.SetConfigName("viddy")
-	v.AddConfigPath(xdg.ConfigHome)
-
-	_ = v.ReadInConfig()
-
-	conf, err := newConfig(v, os.Args[1:])
-	if conf.runtime.help {
+	if os.Args[1] == "help" || os.Args[1] == "--help" || os.Args[1] == "-h" {
 		help()
 		os.Exit(0)
 	}
 
-	if conf.runtime.version {
+	if os.Args[1] == "version" || os.Args[1] == "--version" || os.Args[1] == "-v" {
 		printVersion()
 	}
 
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	tview.Styles = conf.theme.Theme
-
-	app := NewViddy(conf)
+	app := viddy.NewPreconfigedViddy(os.Args[1:])
 
 	if err := app.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/viddy/config.go
+++ b/viddy/config.go
@@ -1,15 +1,15 @@
-package main
+package viddy
 
 import (
 	"errors"
 	"fmt"
+	"github.com/gdamore/tcell/v2"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
 
-	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/spf13/cast"
 	"github.com/spf13/pflag"

--- a/viddy/config_test.go
+++ b/viddy/config_test.go
@@ -1,4 +1,4 @@
-package main
+package viddy
 
 import (
 	"bytes"

--- a/viddy/generator.go
+++ b/viddy/generator.go
@@ -1,4 +1,4 @@
-package main
+package viddy
 
 import "time"
 

--- a/viddy/run.go
+++ b/viddy/run.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package main
+package viddy
 
 import (
 	"bytes"

--- a/viddy/run_windows.go
+++ b/viddy/run_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package main
+package viddy
 
 import (
 	"bytes"

--- a/viddy/snapshot.go
+++ b/viddy/snapshot.go
@@ -1,4 +1,4 @@
-package main
+package viddy
 
 import (
 	"bytes"
@@ -47,8 +47,9 @@ type Snapshot struct {
 	finish chan<- struct{}
 }
 
-//nolint:lll
 // NewSnapshot returns Snapshot object.
+//
+//nolint:lll
 func NewSnapshot(id int64, command string, args []string, shell string, shellOpts string, before *Snapshot, finish chan<- struct{}) *Snapshot {
 	return &Snapshot{
 		id:      id,

--- a/viddy/viddy.go
+++ b/viddy/viddy.go
@@ -1,4 +1,4 @@
-package main
+package viddy
 
 import (
 	"bytes"
@@ -14,9 +14,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/gdamore/tcell/v2"
 	"github.com/moby/term"
 	"github.com/rivo/tview"
+	"github.com/spf13/viper"
 )
 
 type HistoryRow struct {
@@ -139,6 +141,26 @@ func NewViddy(conf *config) *Viddy {
 		currentID:        -1,
 		latestFinishedID: -1,
 	}
+}
+
+func NewPreconfigedViddy(args []string) *Viddy {
+	v := viper.New()
+	v.SetConfigType("toml")
+	v.SetConfigName("viddy")
+	v.AddConfigPath(xdg.ConfigHome)
+
+	_ = v.ReadInConfig()
+
+	conf, err := newConfig(v, args)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	tview.Styles = conf.theme.Theme
+	preConfigedViddy := NewViddy(conf)
+	return preConfigedViddy
 }
 
 func (v *Viddy) ShowLogView(b bool) {
@@ -412,7 +434,7 @@ func (v *Viddy) arrange() {
 }
 
 // Run is entry point to run viddy.
-//nolint: funlen,gocognit,cyclop
+// nolint: funlen,gocognit,cyclop
 func (v *Viddy) Run() error {
 	b := tview.NewTextView()
 	b.SetDynamicColors(true)


### PR DESCRIPTION
This PR should allow importing Viddy tool as a lib in other Golang projects.

Also, I've added the `PreconfiguredNewViddy` func to avoid additional dependencies in 3-party projects.

I suppose this is a good structure to use both:

- as a library
- as a binary

Ready for comments and discussions.
