### PR TITLE
docs: fix typo, connot -> cannot

### DIFF
--- a/config.go
+++ b/config.go
@@ -295,7 +295,7 @@ type parseKeyStrokeError struct {
 }
 
 func (e parseKeyStrokeError) Error() string {
-	return fmt.Sprintf("connot parse key: %q", e.key)
+	return fmt.Sprintf("cannot parse key: %q", e.key)
 }
 
 // ParseKeyStroke parse string describing key.


### PR DESCRIPTION
Found via `typos --format brief`