### PR TITLE
diff: alter foreground color as well

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -168,7 +168,7 @@ func DiffPrettyText(diffs []diffmatchpatch.Diff) string {
 				if unicode.IsSpace(c) {
 					_, _ = buff.WriteRune(c)
 				} else {
-					_, _ = buff.WriteString(color.New(color.BgGreen).Sprintf(string(c)))
+					_, _ = buff.WriteString(color.New(color.FgBlack).Sprintf(color.New(color.BgGreen).Sprintf(string(c))))
 				}
 			}
 		case diffmatchpatch.DiffEqual:


### PR DESCRIPTION
to keep readable contrast between bg and fg

example:
```bash
viddy -d --no-title date
```

before

![image](https://github.com/sachaos/viddy/assets/12046452/eb59628f-5184-463e-b65f-36f2ec8b94d3)

after

![image](https://github.com/sachaos/viddy/assets/12046452/048f271b-68b9-44da-a4f7-7c281bfe2d7d)
