### PR TITLE
check if using powershell in windows

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -101,7 +101,7 @@ func (s *Snapshot) compareFromBefore() error {
 
 //nolint:gosec
 func (s *Snapshot) prepareCommand(commands []string) *exec.Cmd {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && s.shell != "pwsh" {
 		cmdStr := strings.Join(commands, " ")
 		compSec := os.Getenv("COMSPEC")
 


### PR DESCRIPTION
In windows, if the shell is set to "pwsh" (new powershell) there is no need to use %COMSPEC% (cmd). We could run the command with '-c' similar to unix. 