### PR TITLE
fix: ensure prepare_command only appends one -c arguemnt to shell

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,7 @@ impl<S: Store> App<S> {
             Some(ref shell_options) if !shell_options.is_empty() => {
                 shell_options.split(' ').map(|s| s.to_string()).collect()
             }
-            _ => vec!["-c".to_string()],
+            _ => Vec::new(),
         };
         let is_exec = cli.is_exec || default_exec;
         let shell = if is_exec {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -31,7 +31,9 @@ fn prepare_command(
     }
 
     if let Some((shell, mut shell_options)) = shell {
-        shell_options.push("-c".to_string());
+        if !shell_options.contains(&"-c".to_string()) {
+            shell_options.push("-c".to_string());
+        }
         shell_options.push(command.join(" "));
         (shell, shell_options)
     } else {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -31,9 +31,7 @@ fn prepare_command(
     }
 
     if let Some((shell, mut shell_options)) = shell {
-        if !shell_options.contains(&"-c".to_string()) {
-            shell_options.push("-c".to_string());
-        }
+        shell_options.push("-c".to_string());
         shell_options.push(command.join(" "));
         (shell, shell_options)
     } else {


### PR DESCRIPTION
Fish errors out on multiple `-c` invocations where zsh, bash don't.

I originally had a check but instead dropped it in app.rs. I very much don't know rust so feel free to adapt as needed :) 

Shout out to @onedr0p for figuring out how this was broke and finding the redundant appends <3 