### PR TITLE
feat: add -S/--no-status flag to disable status line

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,7 @@ pub struct App<S: Store> {
     is_bell: bool,
     is_fold: bool,
     is_no_title: bool,
+    is_no_status: bool,
     is_skip_empty_diffs: bool,
     showing_execution_id: Option<ExecutionId>,
     shell: Option<(String, Vec<String>)>,
@@ -127,6 +128,7 @@ impl<S: Store> App<S> {
             diff_mode,
             cli.is_bell,
             cli.is_no_title,
+            cli.is_no_status,
             read_only,
             timemachine_mode,
         );
@@ -157,6 +159,7 @@ impl<S: Store> App<S> {
             is_bell: cli.is_bell,
             is_fold: !cli.is_unfold,
             is_no_title: cli.is_no_title,
+            is_no_status: cli.is_no_status,
             is_suspend: Arc::new(Mutex::new(false)),
             is_skip_empty_diffs,
             showing_execution_id: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,9 @@ pub struct Cli {
     #[arg(short = 't', long = "no-title", help = "Turn off header")]
     pub is_no_title: bool,
 
+    #[arg(short = 'S', long = "no-status", help = "Turn off status bar")]
+    pub is_no_status: bool,
+
     #[arg(
         short = 'w',
         long = "unfold",

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -24,6 +24,7 @@ pub struct Home {
     config: Config,
     runtime_config: RuntimeConfig,
     is_no_title: bool,
+    is_no_status: bool,
 
     mode: Mode,
     command_component: Command,
@@ -46,6 +47,7 @@ impl Home {
         diff_mode: Option<DiffMode>,
         is_bell: bool,
         is_no_title: bool,
+        is_no_status: bool,
         read_only: bool,
         timemachine_mode: bool,
     ) -> Self {
@@ -54,6 +56,7 @@ impl Home {
             command_tx: None,
             config: config.clone(),
             is_no_title,
+            is_no_status,
             mode: Default::default(),
             command_component: Command::new(runtime_config.clone()),
             interval_component: Interval::new(runtime_config.clone()),
@@ -188,7 +191,9 @@ impl Component for Home {
         let [prompt, status] =
             Layout::horizontal([Constraint::Fill(100), Constraint::Length(32)]).areas(footer);
         self.prompt_component.draw(f, prompt)?;
-        self.status_component.draw(f, status)?;
+        if !self.is_no_status {
+            self.status_component.draw(f, status)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
closes https://github.com/sachaos/viddy/issues/185

without:
<img width="649" height="48" alt="image" src="https://github.com/user-attachments/assets/18ed74dc-aa71-43ee-a995-ef8906a9db1f" />

with:
<img width="636" height="36" alt="image" src="https://github.com/user-attachments/assets/f7e88c90-3277-4a1b-b668-8a9df691476e" />

I'm not entirely sure if status is the right terminology for that line, happy to change if maintainer can tell me the proper name :sweat_smile: 