### PR TITLE
Invert the disable_auto_save option #181

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,17 +101,18 @@ pub struct Cli {
     #[arg(
         long = "save",
         value_name = "FILE",
-        help = "Path to the backup file. If not provided, a temporary file will be created",
-        conflicts_with_all = ["disable_auto_save", "load"]
+        help = "Path to the backup file",
+        conflicts_with_all = ["auto_save", "load"]
     )]
     pub save: Option<PathBuf>,
 
     #[arg(
-        long = "disable_auto_save",
-        help = "Disable to save automatically",
+        long = "auto-save",
+        short = 'a',
+        help = "Enable saving to a temporary file",
         conflicts_with_all = ["save", "load"]
     )]
-    pub disable_auto_save: bool,
+    pub auto_save: bool,
 
     #[arg(long = "disable_mouse", help = "Stop handling mouse events")]
     pub disable_mouse: bool,
@@ -121,7 +122,7 @@ pub struct Cli {
         alias = "lookback",
         value_name = "FILE",
         help = "Path to the backup file",
-        conflicts_with_all = ["save", "disable_auto_save", "shell", "shell_options", "is_exec", "is_bell", "is_precise", "interval"]
+        conflicts_with_all = ["save", "auto_save", "shell", "shell_options", "is_exec", "is_bell", "is_precise", "interval"]
     )]
     pub load: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,19 +50,7 @@ async fn tokio_main() -> Result<()> {
         return Err(eyre!("Can not use --load with command"));
     }
 
-    if args.disable_auto_save {
-        let store = store::memory::MemoryStore::new();
-        let mut app = App::new(args, store, false)?;
-        app.run().await?;
-    } else if let Some(l) = &args.load {
-        let store = store::sqlite::SQLiteStore::new(l.clone(), false)?;
-        let mut app = App::new(args.clone(), store, true)?;
-        app.run().await?;
-    } else if let Some(b) = &args.save {
-        let store = store::sqlite::SQLiteStore::new(b.clone(), true)?;
-        let mut app = App::new(args.clone(), store, false)?;
-        app.run().await?;
-    } else {
+    if args.auto_save {
         let tmp_dir = tempfile::tempdir()?;
         let tmp_path = tmp_dir.into_path();
         let file_path = tmp_path.join("backup.sqlite");
@@ -75,6 +63,18 @@ async fn tokio_main() -> Result<()> {
             "Run `viddy --lookback {}` to load backup",
             file_path.to_str().unwrap()
         );
+    } else if let Some(l) = &args.load {
+        let store = store::sqlite::SQLiteStore::new(l.clone(), false)?;
+        let mut app = App::new(args.clone(), store, true)?;
+        app.run().await?;
+    } else if let Some(b) = &args.save {
+        let store = store::sqlite::SQLiteStore::new(b.clone(), true)?;
+        let mut app = App::new(args.clone(), store, false)?;
+        app.run().await?;
+    } else {
+        let store = store::memory::MemoryStore::new();
+        let mut app = App::new(args, store, false)?;
+        app.run().await?;
     }
 
     Ok(())


### PR DESCRIPTION
Adopt --auto-save, instead of --disable-auto-save.
By default, use in memory history unless the user requests writing to disk.