### PR TITLE
fix: create backup with owner-only permissions (#195)

### DIFF
--- a/src/components/help.rs
+++ b/src/components/help.rs
@@ -27,7 +27,7 @@ fn keys_str(
     keybindings: &HashMap<(Mode, String), Vec<Vec<KeyEvent>>>,
     mode: Mode,
     action: String,
-) -> Vec<Span> {
+) -> Vec<Span<'_>> {
     keybindings.get(&(mode, action.clone())).map_or_else(
         || vec![Span::from("None")],
         |keys_list| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,16 @@ async fn tokio_main() -> Result<()> {
         let mut app = App::new(args.clone(), store, false)?;
         app.run().await?;
     } else {
+        // Create the temporary directory with owner-only permissions so the
+        // backup (which may contain sensitive output) is not world-readable (#195).
+        #[cfg(unix)]
+        let tmp_dir = {
+            use std::os::unix::fs::PermissionsExt;
+            tempfile::Builder::new()
+                .permissions(std::fs::Permissions::from_mode(0o700))
+                .tempdir()?
+        };
+        #[cfg(not(unix))]
         let tmp_dir = tempfile::tempdir()?;
         let tmp_path = tmp_dir.into_path();
         let file_path = tmp_path.join("backup.sqlite");

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -28,6 +28,7 @@ impl SQLiteStore {
             std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
+                .truncate(true)
                 .mode(0o600)
                 .open(&path)?;
         }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -20,6 +20,18 @@ impl SQLiteStore {
             std::fs::remove_file(&path)?;
         }
 
+        // Pre-create the database file with owner-only permissions before SQLite
+        // opens it, otherwise the backup is created world-readable (#195).
+        #[cfg(unix)]
+        if init {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .mode(0o600)
+                .open(&path)?;
+        }
+
         let conn = Connection::open_with_flags(
             path,
             rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_CREATE,


### PR DESCRIPTION
## Summary

Fixes the backup (a sqlite file containing captured command output) being created with **world-readable** permissions.

Previously the temporary directory was created as `0o755` and the file as `0o644`, meaning any user on the same system could read the backup contents (i.e. all command output):

```
drwxr-xr-x  /tmp/.tmpXXXXXX
-rw-r--r--  /tmp/.tmpXXXXXX/backup.sqlite
```

## Why

The backup stores the command's stdout/stderr verbatim, which may contain sensitive information. On a shared machine, allowing other users to read it is a security issue (information disclosure). Only the owner should be able to access it.

## Changes

- **`src/main.rs`**: Create the default temporary directory via `tempfile::Builder::permissions(0o700)`. Setting the permissions atomically at creation time avoids the race window where a later `chmod` would briefly leave the directory world-readable. Making the directory `0o700` also protects everything inside it, including the main DB and SQLite's `-wal` / `-journal` sidecar files.
- **`src/store/sqlite.rs`**: Pre-create the DB file with `OpenOptions::mode(0o600)` when `init` is set. This also protects the file permissions for the `--save` case where the user provides an explicit path.

Both are guarded by `#[cfg(unix)]` and have no effect on non-unix platforms.

## How to test

```sh
cargo build   # builds successfully (only a pre-existing lifetime warning)
viddy -n1 echo hello   # after exit, note the printed backup.sqlite path
find /tmp/.tmpXXXXXX -ls
# the directory should be drwx------ (0o700) and the file -rw------- (0o600)
```

## Review points

- The approach of setting permissions atomically at directory creation time (avoiding a post-creation `chmod` race window).
- The two-layer defense (directory `0o700` + file `0o600`), covering both the default temporary backup and the `--save` case.

## Related issue

Fixes #195
