### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,7 +3029,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "viddy"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "ansi-parser",
  "ansi-to-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viddy"
 license = "MIT"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "A modern watch command"
 


### PR DESCRIPTION
## Summary

Bump the version from `1.3.0` to `1.3.1` in preparation for the v1.3.1 release.

This release includes the security fix from #196 (backup files/directory are now created with owner-only permissions, fixing #195).

## Changes

- `Cargo.toml`: `version = "1.3.1"`
- `Cargo.lock`: updated accordingly

## How to test

```sh
cargo build
```

## Release flow

After merging, pushing the `v1.3.1` tag triggers the CD workflow which builds the release binaries and publishes the GitHub Release.

## Related

- #195
- #196
