### PR TITLE
Respect disable_mouse when resuming from suspend

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -527,7 +527,7 @@ impl<S: Store> App<S> {
                 tui = tui::Tui::new()?
                     .tick_rate(self.tick_rate)
                     .frame_rate(self.frame_rate);
-                tui = tui.mouse(true);
+                tui = tui.mouse(!self.disable_mouse);
                 tui.enter()?;
             } else if self.should_quit {
                 tui.stop()?;


### PR DESCRIPTION
After suspending with Ctrl-Z and resuming, the TUI was rebuilt with `mouse(true)` unconditionally, re-enabling mouse capture even when `--disable_mouse` or the `disable_mouse` config option was set. Use `!self.disable_mouse`, matching the startup path.